### PR TITLE
DN-1_strapi-plugin-vercel-deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,14 @@ APP_KEYS=['', '']
 JWT_SECRET=
 API_TOKEN_SALT=
 ADMIN_JWT_SECRET=
+# Environment variables used for testing
+# AWS – you will need to modify `config/plugins.js` and `config/middlewares.js` in order to use AWS values in the local environment
+# AWS_ACCESS_KEY_ID=
+# AWS_ACCESS_SECRET=
+# AWS_REGION=
+# AWS_BUCKET=
+# Vercel Deploy – you will need to modify `config/plugins.js` in order to use Vercel Deploy values in the local environment
+# VERCEL_DEPLOY_PLUGIN_HOOK=
+# VERCEL_DEPLOY_PLUGIN_API_TOKEN=
+# VERCEL_DEPLOY_PLUGIN_APP_FILTER=
+# VERCEL_DEPLOY_PLUGIN_ROLES=

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If this is your first time running the repo locally you may need to install pyth
 
 # Environment variables
 
-## Environment bariables required for local development
+## Environment variables required for local development
 
 - Copy `.env.example` to `.env` and add the following:
   - ```
@@ -79,6 +79,23 @@ Without a solution for hosting persistent images `test` and `production` environ
     - follow the bucket settings listed in the guide
     - An additional step may be needed to allow your apps IAM user to upload by navigating to the bucket `Permissions` tab and changing `Object Ownership` to `Bucket owner preferred`
     - Repeat this process for your test environment uploads bucket.
+
+### **Setting up Strapi Vercel Deploy plugin**
+
+This project uses the Vercel Deploy plugin to manage redeploys of the frontend NextJs app when content changes have been made in the Strapi backend that don’t require frontend code changes. Configuration details for that plugin can be found here:
+
+- [Vercel Deploy | Strapi Market](https://market.strapi.io/plugins/strapi-plugin-vercel-deploy)
+- [npm: strapi-plugin-vercel-deploy](https://www.npmjs.com/package/strapi-plugin-vercel-deploy)
+- [Github - gianlucaparadise/strapi-plugin-vercel-deploy: Strapi v4 plugin to trigger and monitor a deployment on Vercel](https://github.com/gianlucaparadise/strapi-plugin-vercel-deploy)
+
+The plugin itself requires the uses of 4 new environment variables `VERCEL_DEPLOY_PLUGIN_HOOK`, `VERCEL_DEPLOY_PLUGIN_API_TOKEN`, `VERCEL_DEPLOY_PLUGIN_APP_FILTER`, `VERCEL_DEPLOY_PLUGIN_ROLES`
+
+- `VERCEL_DEPLOY_PLUGIN_HOOK` can be configured in a Vercel projects `settings` tab
+- `VERCEL_DEPLOY_PLUGIN_API_TOKEN` can be configured here: [Tokens – Account – Dashboard – Vercel](https://vercel.com/account/tokens). Tokens should be assigned to specific git branches like `master` or `test`.
+- `VERCEL_DEPLOY_PLUGIN_APP_FILTER` is equal to your app name ex: websiteName-next
+- `VERCEL_DEPLOY_PLUGIN_ROLES` is configured in `config/plugins.js` to consume only one Strapi role, currently this value should default to `strapi-super-admin`. `config/plugins.js` can be modified to consume an array of strings if more than one role will be expected to be able to use the Vercel Deploy plugin.
+
+### **Additional Resources**
 
 Additional resources on deploying Strapi to other environments can be found here: [Deployment - Strapi Developer Docs](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment.html)
 

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -23,8 +23,27 @@ module.exports = ({ env }) => {
           },
         },
       },
+      "vercel-deploy": {
+        enabled: true,
+        config: {
+          deployHook: env("VERCEL_DEPLOY_PLUGIN_HOOK"),
+          apiToken: env("VERCEL_DEPLOY_PLUGIN_API_TOKEN"),
+          appFilter: env("VERCEL_DEPLOY_PLUGIN_APP_FILTER"),
+          roles: [env("VERCEL_DEPLOY_PLUGIN_ROLES")],
+        },
+      },
     };
   }
 
-  return {};
+  return {
+    "vercel-deploy": {
+      enabled: true,
+      config: {
+        deployHook: env("VERCEL_DEPLOY_PLUGIN_HOOK"),
+        apiToken: env("VERCEL_DEPLOY_PLUGIN_API_TOKEN"),
+        appFilter: env("VERCEL_DEPLOY_PLUGIN_APP_FILTER"),
+        roles: [env("VERCEL_DEPLOY_PLUGIN_ROLES")],
+      },
+    },
+  };
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "@strapi/provider-upload-aws-s3": "^4.5.3",
     "@strapi/strapi": "^4.3.3",
     "better-sqlite3": "7.6.2",
-    "pg": "^8.7.3"
+    "pg": "^8.7.3",
+    "strapi-plugin-vercel-deploy": "^1.4.0"
   },
   "author": {
     "name": "Ian Roberts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3144,6 +3144,13 @@ axios@0.27.2:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
 
+axios@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
+
 babel-loader@8.2.5:
   version "8.2.5"
   resolved "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.5.tgz#d45f585e654d5a5d90f5350a779d7647c5ed512e"
@@ -5343,7 +5350,7 @@ fn.name@1.x.x:
   resolved "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.9:
+follow-redirects@^1.0.0, follow-redirects@^1.14.8, follow-redirects@^1.14.9:
   version "1.15.2"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -8795,7 +8802,7 @@ react-input-autosize@^3.0.0:
   dependencies:
     prop-types "^15.5.8"
 
-react-intl@5.25.1:
+react-intl@5.25.1, react-intl@^5.25.1:
   version "5.25.1"
   resolved "https://registry.npmjs.org/react-intl/-/react-intl-5.25.1.tgz#68a73aefc485c9bf70062381ae7f6f4791680879"
   integrity sha512-pkjdQDvpJROoXLMltkP/5mZb0/XqrqLoPGKUCfbdkP8m6U9xbK40K51Wu+a4aQqTEvEK5lHBk0fWzUV72SJ3Hg==
@@ -9852,6 +9859,14 @@ std-env@^3.0.1:
   version "3.3.0"
   resolved "https://registry.npmjs.org/std-env/-/std-env-3.3.0.tgz#86b5b5d416c5744b3fdeac6893c2b98196fc1a55"
   integrity sha512-cNNS+VYsXIs5gI6gJipO4qZ8YYT274JHvNnQ1/R/x8Q8mdP0qj0zoMchRXmBNPqp/0eOEhX+3g7g6Fgb7meLIQ==
+
+strapi-plugin-vercel-deploy@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/strapi-plugin-vercel-deploy/-/strapi-plugin-vercel-deploy-1.4.0.tgz#bf4f5c5fde635c48d6327a3e99732a07e495e718"
+  integrity sha512-hUwUM3WjIsFRSlIU9SMGBFc7UOpoyPdW/yEhFtUdlFIb5G2+tALgS/1kWXVnP61VWb1nsqqjtNoxCtxsif9FvA==
+  dependencies:
+    axios "^0.26.1"
+    react-intl "^5.25.1"
 
 stream-browserify@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Adds `strapi-vercel-deploy-plugin` package
See:
- https://market.strapi.io/plugins/strapi-plugin-vercel-deploy
- https://www.npmjs.com/package/strapi-plugin-vercel-deploy
- https://github.com/gianlucaparadise/strapi-plugin-vercel-deploy

Updates configuration to use environment variables
- `VERCEL_DEPLOY_PLUGIN_HOOK=`
- `VERCEL_DEPLOY_PLUGIN_API_TOKEN=`
- `VERCEL_DEPLOY_PLUGIN_APP_FILTER=`
- `VERCEL_DEPLOY_PLUGIN_ROLES=`

Adds documentation to README. Separately documentation has been added to Jira